### PR TITLE
Allow disabling persistent volumes

### DIFF
--- a/atomix/templates/statefulset.yaml
+++ b/atomix/templates/statefulset.yaml
@@ -97,8 +97,10 @@ spec:
           initialDelaySeconds: 60
           timeoutSeconds: 10
         volumeMounts:
+        {{- if .Values.persistence.enabled }}
         - name: data
           mountPath: /var/lib/atomix
+        {{- end }}
         - name: system-config
           mountPath: /etc/atomix/system
         - name: user-config
@@ -119,6 +121,7 @@ spec:
           name: {{ template "fullname" . }}-config
       - name: system-config
         emptyDir: {}
+  {{- if .Values.persistence.enabled }}
   volumeClaimTemplates:
   - metadata:
       name: data
@@ -141,3 +144,4 @@ spec:
       resources:
         requests:
           storage: {{ .Values.persistence.size | quote }}
+  {{- end }}

--- a/atomix/values.yaml
+++ b/atomix/values.yaml
@@ -45,6 +45,7 @@ podDisruptionBudget:
   # minAvailable: 1
 
 persistence:
+  enabled: true
   accessModes:
     - ReadWriteOnce
   size: 10Gi


### PR DESCRIPTION
Useful for testing scenarios where you want to be able to easily tear down Atomix and restart with a clean cluster.